### PR TITLE
refactor: add support for application/octet-stream

### DIFF
--- a/src/schema-routes/schema-routes.ts
+++ b/src/schema-routes/schema-routes.ts
@@ -296,7 +296,10 @@ export class SchemaRoutes {
       return CONTENT_KIND.FORM_DATA;
     }
 
-    if (contentTypes.some((contentType) => contentType.includes("image/"))) {
+    if (
+      contentTypes.some((contentType) => contentType.includes("image/")) || 
+      contentTypes.some((contentType) => contentType.includes("application/octet-stream"))
+    ) {
       return CONTENT_KIND.IMAGE;
     }
 


### PR DESCRIPTION
This is a small code change to allow us using blob as a return type
We use this in the download endpoints

The code change is taken from this other fork
https://github.com/acacode/swagger-typescript-api/pull/588/files